### PR TITLE
edited README.md, Makefile, and client.c for Python 3.x compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,38 @@
+
+
 ifneq ($(KERNELRELEASE),)
 	obj-m := detectiontool.o
 
 else
+
+define ANNOUNCE_BODY_1
+--------------------------------------------------------------------------
+Please execute next command "make client" to create the userspace tool. 
+--------------------------------------------------------------------------
+endef
+
+define ANNOUNCE_BODY_2
+--------------------------------------------------------------------------
+Use the command "insmod detectiontool.ko" to load the kernel module.
+--------------------------------------------------------------------------
+endef
+
+export ANNOUNCE_BODY
+	python_version_full := $(wordlist 2,4,$(subst ., ,$(shell python3 --version 2>&1)))
+	python_version_major := $(word 1,${python_version_full})
+	python_version_minor := $(word 2,${python_version_full})
 	KERNELDIR ?=/lib/modules/$(shell uname -r)/build
 	PWD := $(shell pwd)
 
-default:
+kernel:
 	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules
-
+	@echo "$$ANNOUNCE_BODY_1"
+client: detectiontool.ko
+	gcc -fPIC client.c $$(python$(python_version_major).$(python_version_minor)-config --cflags) $$(python$(python_version_major).$(python_version_minor)-config --ldflags) -o client
+	@echo "$$ANNOUNCE_BODY_2"
 endif
 
 
 clean:
 	$(MAKE) -C $(KERNELDIR) M=$(PWD) clean
+	rm -rf *.ko *.mod.* *.o *.order *.symvers client 

--- a/Makefile
+++ b/Makefile
@@ -1,37 +1,22 @@
-
-
 ifneq ($(KERNELRELEASE),)
 	obj-m := detectiontool.o
 
 else
-
-define ANNOUNCE_BODY_1
---------------------------------------------------------------------------
-Please execute next command "make client" to create the userspace tool. 
---------------------------------------------------------------------------
-endef
-
-define ANNOUNCE_BODY_2
---------------------------------------------------------------------------
-Use the command "insmod detectiontool.ko" to load the kernel module.
---------------------------------------------------------------------------
-endef
-
-export ANNOUNCE_BODY
-	python_version_full := $(wordlist 2,4,$(subst ., ,$(shell python3 --version 2>&1)))
-	python_version_major := $(word 1,${python_version_full})
-	python_version_minor := $(word 2,${python_version_full})
 	KERNELDIR ?=/lib/modules/$(shell uname -r)/build
 	PWD := $(shell pwd)
 
+python_version_full := $(wordlist 2,4,$(subst ., ,$(shell python3 --version 2>&1)))
+python_version_major := $(word 1,${python_version_full})
+python_version_minor := $(word 2,${python_version_full})
+
+all: kernel client
+
 kernel:
 	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules
-	@echo "$$ANNOUNCE_BODY_1"
+
 client: detectiontool.ko
 	gcc -fPIC client.c $$(python$(python_version_major).$(python_version_minor)-config --cflags) $$(python$(python_version_major).$(python_version_minor)-config --ldflags) -o client
-	@echo "$$ANNOUNCE_BODY_2"
 endif
-
 
 clean:
 	$(MAKE) -C $(KERNELDIR) M=$(PWD) clean

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ pip3 install pytsk3
 git clone https://github.com/lckjosh/DetectionTool.git
 cd DetectionTool
 make
+make client
 chmod +x ./hidden-inode-detector.py
-gcc client.c -o client
 ```
 __NOTE: RUN `sudo ./client -f` upon installation to form initial baseline for detecting hidden inodes.__
 # Usage

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ For more detailed explanations, please visit the [wiki](https://github.com/lckjo
 - Linux Headers 
 - GCC Compiler (Version > 5.0.0)
 - The Sleuth Kit (TSK) 
-- Python (Version 3.5)
-- pytsk3 module
+- Python 3
+- pytsk3 library
 
 For Debian-based distros: 
 ```
@@ -28,8 +28,6 @@ pip3 install pytsk3
 git clone https://github.com/lckjosh/DetectionTool.git
 cd DetectionTool
 make
-make client
-chmod +x ./hidden-inode-detector.py
 ```
 __NOTE: RUN `sudo ./client -f` upon installation to form initial baseline for detecting hidden inodes.__
 # Usage

--- a/client.c
+++ b/client.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 #include "detectpids.c"
-//#include "detectinodes.c"
+#include "detectinodes.c"
 
 // client program for detection tool
 // adapted from LilyOfTheValley rootkit
@@ -111,7 +111,8 @@ int main(int argc, char **argv)
          {
             __err("[__ERROR_2__]", perror, -1);
          }
-         int status = system("./hidden-inode-detector.py /dev/sda1 / /");
+         // int status = system("./hidden-inode-detector.py /dev/sda1 / /");
+         int status = hideinodedetector();
          if (status != 0)
          {
             printf("client.c: Python script (hidden-inode-detector.py) failed to execute completely due to a raised exception.\n");

--- a/detectinodes.c
+++ b/detectinodes.c
@@ -1,4 +1,5 @@
-#include <python3.5m/Python.h> // python-c API, python3.5m is in Ubuntu 16.04 TLS
+#include <Python.h> // python-c API
+//#include <python3.5m/Python.h> 
 #include <wchar.h>
 
 #define PYTHON_FILENAME "hidden-inode-detector.py"


### PR DESCRIPTION
- Changed README.md to change compilation steps
- Changed Makefile to obtain users python3 version and "make client" to compile gcc
- Changed client.c back to including detectinodes.c

Now works no matter what python3 version is being used, including default python version for ubuntu 18.04